### PR TITLE
Added initial portal tab and data format overview

### DIFF
--- a/_data/sidebars/sparc_sidebar.yml
+++ b/_data/sidebars/sparc_sidebar.yml
@@ -3,7 +3,7 @@
 entries:
 - title: sidebar
   product: SPARC Documentation
-  version: 
+  version:
   folders:
 
   - title: Overview
@@ -11,7 +11,7 @@ entries:
     folderitems:
     - title: DRC Resources and Accounts
       url: /user_accounts.html
-      output: web, pdf  
+      output: web, pdf
     - title: SPARC Confidentiality Agreement
       url: /sparc_cda.html
       output: web, pdf
@@ -21,7 +21,7 @@ entries:
     - title: Frequently Asked Questions
       url: /faq.html
       output: web, pdf
-  - title: Submitting Data 
+  - title: Submitting Data
     output: web, pdf
     folderitems:
     - title: Uploading Files
@@ -42,12 +42,16 @@ entries:
     - title: DAT-Core Roadmap
       url: /dat_roadmap.html
       output: web, pdf
-  - title: MAP-Core 
+  - title: MAP-Core
     output: web, pdf
     folderitems:
     - title: Webinar by Peter Hunter
       url: /Webinar_by_PeterHunter.html
       output: web, pdf
-   
-
-
+  - title: SPARC Portal
+    output: web, pdf
+    folderitems:
+    - title: SPARC Dataset Format Overview
+      url: /sparc_data_format.html
+      output: web, pdf
+      

--- a/pages/sparc_portal/sparc_data_format.md
+++ b/pages/sparc_portal/sparc_data_format.md
@@ -1,0 +1,19 @@
+---
+title: "Overview of SPARC Dataset Format"
+keywords: documentation, github
+sidebar: sparc_sidebar
+permalink: sparc_data_format.html
+summary: This page provides an overview of the SPARC data format.
+folder: general
+---
+
+## Overview of SPARC Dataset Format
+
+Each dataset dataset will comprise the following:
+- A protocol that has been [submitted to Protocols.io]
+- Data files organized in folders according to [SPARC guidelines](https://docs.google.com/presentation/d/1EQPn1FmANpPsFt3CguU-JOQVMMlJsNXluQAK_gb2qVg/edit#slide=id.p1).  The SPARC Dataset Structure may be [downloaded as a zip file](https://drive.google.com/open?id=1mtZ5sL1lYcA2zHVsrYOKVeH2X-VlJT6P) or you may create them on your own. For help with working with the SPARC Dataset Structure, which is based on the [BIDS specification](http://bids.neuroimaging.io/), contact **sparc@neuinfo.org**.
+- Metadata files and documentation organized according to the SPARC Dataset Structure.  Templates are provided in the zip file (docs file) and include the following:
+  - [Submission metadata](https://drive.google.com/open?id=1OhXmssY9GK8ebOmrvib1B9xbeqoVEOBA)
+  - [Dataset description for publication](https://drive.google.com/file/d/1-VqBo63oKlxVdt8nNnbzVK0NxAHwc8-L/view?usp=sharing)
+  - A representative figure that will be published along with the descriptive metadata
+  - Experimental metadata specified by the SPARC Data Standards Committee based on the Minimal Information for a Neuroscience Dataset (MINDS) specification.  MINDS metadata fields have been incorporated into the [subjects](https://drive.google.com/open?id=1IDo5INrqtIu1sTJW2mICzuGEAKqv5eGg) and [samples](https://drive.google.com/open?id=1ROCsuBjMWBDmCTpTGZsUQDDgYtm-nqYG) templates available in the zip file.  An annotated list of these fields can be found [here](https://docs.google.com/spreadsheets/d/1e61r3F2weausmBhqFK8RlYLviC3rya44so5m15mPRTw/edit#gid=108617967).


### PR DESCRIPTION
Created new folder in pages for the sparc-portal documentation and added the initial tab in the sidebar. Also added the initial data format overview page.