### PR TITLE
adding an initial link to the portal documentation for the MAPcore pages

### DIFF
--- a/_data/sidebars/sparc_sidebar.yml
+++ b/_data/sidebars/sparc_sidebar.yml
@@ -54,4 +54,7 @@ entries:
     - title: SPARC Dataset Format Overview
       url: /sparc_data_format.html
       output: web, pdf
-      
+    - title: Map visualization docs
+      url: /sparc_portal_maps.html
+      output: web, pdf
+

--- a/pages/sparc_portal/sparc_portal_maps.md
+++ b/pages/sparc_portal/sparc_portal_maps.md
@@ -1,0 +1,12 @@
+---
+title: "Map visualization documentation"
+keywords: documentation, MAPcore
+sidebar: sparc_sidebar
+permalink: sparc_portal_maps.html
+summary: This page provides a link into the SPARC portal map visualization docs.
+folder: general
+---
+
+## Map visualization documentation
+
+The map visualization documentation is currently available here: https://mapcore-documentation.readthedocs.io.


### PR DESCRIPTION
Not able to test locally, but hopefully this works :)