### PR TITLE
Adding SAWG section created by Maryann Martone

### DIFF
--- a/_data/sidebars/sparc_sidebar.yml
+++ b/_data/sidebars/sparc_sidebar.yml
@@ -36,6 +36,9 @@ entries:
     - title: SODA Data organization tool
       url: /soda.html
       output: web, pdf
+    - title: About SAWG
+      url: /sawg.html
+      output: web, pdf  
   - title: Data Resource Center
     output: web, pdf
     folderitems:

--- a/pages/data_submission/sawg.md
+++ b/pages/data_submission/sawg.md
@@ -1,0 +1,23 @@
+---
+title: "SAWG: SPARC Anatomical Working Group"
+keywords: SAWG,sawg
+sidebar: sparc_sidebar
+permalink: sawg.html
+summary: About SAWG
+folder: general
+---
+
+
+## SPARC Anatomical Working Group (SAWG)
+
+The Stimulating Peripheral Activity to Relieve Conditions (SPARC) effort is the result of National Institutes of Health’s (NIH) drive to map out the neural circuitry responsible for visceral control in higher vertebrates.
+
+The management of multimodal anatomical knowledge is one of the mainstays of MAP-CORE’s effort in SPARC. At the core of this effort is the curation of computable and FAIR knowledge for the inferencing of multiscale parts and connectivity route pathways in support of SPARC metadata discovery.
+
+The SPARC Anatomy Working Group (SAWG) is responsible for the integrity of anatomical knowledge in SPARC. In particular, it provides the relevant guidance and expertise about:
+
+1. Defining and naming anatomical terms
+2. Maintaining ontologies of anatomical knowledge
+3. Compiling and curating computable knowledge about multiscale routes pathways
+
+More detailed information can be found at the [SAWG Home Page](http://ontology.neuinfo.org/trees/sparc/).


### PR DESCRIPTION
Adding a section about SAWG written by Maryann Martone. 

Original file location: https://github.com/Blackfynn/docs.sparc.science/pull/29
