### PR TITLE
Changed the name of sidebar menu item for SAWG

### DIFF
--- a/_data/sidebars/sparc_sidebar.yml
+++ b/_data/sidebars/sparc_sidebar.yml
@@ -36,7 +36,7 @@ entries:
     - title: SODA Data organization tool
       url: /soda.html
       output: web, pdf
-    - title: About SAWG
+    - title: SAWG:SPARC Anatomical Working Group
       url: /sawg.html
       output: web, pdf  
   - title: Data Resource Center


### PR DESCRIPTION
As per the request from Maryann, changed the name of the sidebar menu item for SAWG. 